### PR TITLE
Feature papi

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -92,21 +92,21 @@ if(ETOPS_USE_PAPI)
   
   ExternalProject_Add(papi_external
     GIT_REPOSITORY https://github.com/icl-utk-edu/papi.git
-    GIT_TAG master
-        PREFIX ${PAPI_PREFIX_DIR}
-        SOURCE_DIR ${PAPI_SOURCE_DIR}
-        BUILD_IN_SOURCE 1
-        CONFIGURE_COMMAND ${CMAKE_COMMAND} -E chdir <SOURCE_DIR>/src ./configure --prefix=<SOURCE_DIR>/src/install
-        BUILD_COMMAND ${CMAKE_COMMAND} -E chdir <SOURCE_DIR>/src make
-        INSTALL_COMMAND ${CMAKE_COMMAND} -E chdir <SOURCE_DIR>/src make install
-        BUILD_BYPRODUCTS "${PAPI_INSTALL_DIR}/lib/libpapi.a"
+    GIT_TAG 4c51744
+    PREFIX ${PAPI_PREFIX_DIR}
+    SOURCE_DIR ${PAPI_SOURCE_DIR}
+    BUILD_IN_SOURCE 1
+    CONFIGURE_COMMAND ${CMAKE_COMMAND} -E chdir <SOURCE_DIR>/src ./configure --prefix=<SOURCE_DIR>/src/install
+    BUILD_COMMAND ${CMAKE_COMMAND} -E chdir <SOURCE_DIR>/src make
+    INSTALL_COMMAND ${CMAKE_COMMAND} -E chdir <SOURCE_DIR>/src make install
+    BUILD_BYPRODUCTS "${PAPI_INSTALL_DIR}/lib/libpapi.a"
   )
 
     add_library(PAPI::PAPI STATIC IMPORTED GLOBAL)
     set_target_properties(PAPI::PAPI PROPERTIES
-    IMPORTED_LOCATION "${PAPI_INSTALL_DIR}/lib/libpapi.a"
-        INTERFACE_INCLUDE_DIRECTORIES "${PAPI_INSTALL_DIR}/include"
-  )
+      IMPORTED_LOCATION "${PAPI_INSTALL_DIR}/lib/libpapi.a"
+      INTERFACE_INCLUDE_DIRECTORIES "${PAPI_INSTALL_DIR}/include"
+    )
   add_dependencies(PAPI::PAPI papi_external)
 
   target_link_libraries(TensorOperation PUBLIC PAPI::PAPI)

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -17,6 +17,7 @@ endif()
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+option(ETOPS_USE_PAPI "Enable Papi profiling" OFF)
 
 # ------------------------------------------------------------
 # einsum_ir
@@ -75,6 +76,41 @@ else()
         INSTALL_RPATH "$ORIGIN"
         LINK_FLAGS "-Wl,--enable-new-dtags"
     )
+endif()
+
+if(ETOPS_USE_PAPI)
+  include(ExternalProject)
+
+  set(PAPI_PREFIX_DIR "${CMAKE_BINARY_DIR}/external/papi")
+  set(PAPI_SOURCE_DIR "${PAPI_PREFIX_DIR}/src/papi_external")
+  set(PAPI_INSTALL_DIR "${PAPI_SOURCE_DIR}/src/install")
+
+    file(MAKE_DIRECTORY
+        "${PAPI_INSTALL_DIR}/include"
+        "${PAPI_INSTALL_DIR}/lib"
+    )
+  
+  ExternalProject_Add(papi_external
+    GIT_REPOSITORY https://github.com/icl-utk-edu/papi.git
+    GIT_TAG master
+        PREFIX ${PAPI_PREFIX_DIR}
+        SOURCE_DIR ${PAPI_SOURCE_DIR}
+        BUILD_IN_SOURCE 1
+        CONFIGURE_COMMAND ${CMAKE_COMMAND} -E chdir <SOURCE_DIR>/src ./configure --prefix=<SOURCE_DIR>/src/install
+        BUILD_COMMAND ${CMAKE_COMMAND} -E chdir <SOURCE_DIR>/src make
+        INSTALL_COMMAND ${CMAKE_COMMAND} -E chdir <SOURCE_DIR>/src make install
+        BUILD_BYPRODUCTS "${PAPI_INSTALL_DIR}/lib/libpapi.a"
+  )
+
+    add_library(PAPI::PAPI STATIC IMPORTED GLOBAL)
+    set_target_properties(PAPI::PAPI PROPERTIES
+    IMPORTED_LOCATION "${PAPI_INSTALL_DIR}/lib/libpapi.a"
+        INTERFACE_INCLUDE_DIRECTORIES "${PAPI_INSTALL_DIR}/include"
+  )
+  add_dependencies(PAPI::PAPI papi_external)
+
+  target_link_libraries(TensorOperation PUBLIC PAPI::PAPI)
+  target_compile_definitions(TensorOperation PUBLIC ETOPS_USE_PAPI)
 endif()
 
 target_compile_features(_etops_core PUBLIC)

--- a/python/src/TensorOperation.cpp
+++ b/python/src/TensorOperation.cpp
@@ -27,6 +27,44 @@ int64_t einsum_ir::py::TensorOperation::get_num_threads( int64_t num_threads ) {
   return l_num_threads;
 }
 
+einsum_ir::py::TensorOperation::error_t
+einsum_ir::py::TensorOperation::set_papi_config( std::string const & i_profile,
+                                                 std::vector< std::string > const & i_events ) {
+#ifdef ETOPS_USE_PAPI
+  if( i_profile == "default" ) {
+    m_papi_event_names = { "PAPI_TOT_INS", "PAPI_TOT_CYC" };
+    m_papi_enabled = true;
+    return error_t::success;
+  }
+
+  if( i_profile == "cache" ) {
+    m_papi_event_names = { "PAPI_L1_DCM", "PAPI_L2_DCM", "PAPI_L3_DCM", "PAPI_TLB_DM" };
+    m_papi_enabled = true;
+    return error_t::success;
+  }
+
+  if( i_profile == "custom" ) {
+    if( i_events.size() == 0 ) {
+      std::cerr << "PAPI profile 'custom' requires at least one event name." << std::endl;
+      m_papi_enabled = false;
+      return error_t::invalid_papi_config;
+    }
+    m_papi_event_names = i_events;
+    m_papi_enabled = true;
+    return error_t::success;
+  }
+
+  std::cerr << "Unsupported PAPI profile: '" << i_profile
+            << "'. Supported profiles are: default, cache, custom." << std::endl;
+  m_papi_enabled = false;
+  return error_t::invalid_papi_config;
+#else
+  (void) i_profile;
+  (void) i_events;
+  return error_t::success;
+#endif
+}
+
 void einsum_ir::py::TensorOperation::calculate_sfc_sizes(
   std::vector< dim_t >   const & dim_types,
   std::vector< exec_t >  const & exec_types,
@@ -459,12 +497,26 @@ einsum_ir::py::TensorOperation::error_t einsum_ir::py::TensorOperation::setup_bi
 void einsum_ir::py::TensorOperation::execute( void const * tensor_in0,
                                               void const * tensor_in1,
                                               void       * tensor_out) {
+#ifdef ETOPS_USE_PAPI
+  if( m_papi_enabled ) {
+    // Start PAPI counters
+    papi_start();
+  }
+#endif                  
   if (m_op_type == op_type_t::unary) {
     m_backend_unary.eval(tensor_in0, tensor_out);
   }
   else if (m_op_type == op_type_t::binary) {
     m_backend_binary.contract(tensor_in0, tensor_in1, nullptr, tensor_out);
   }
+#ifdef ETOPS_USE_PAPI
+  if( m_papi_enabled ) {
+    // Stop PAPI counters and print results
+    papi_stop();
+    papi_print_results();
+  }
+#endif
+
 }
 
 einsum_ir::py::OptimizationConfig einsum_ir::py::TensorOperation::get_default_optimization_config() {
@@ -769,3 +821,79 @@ einsum_ir::py::TensorOperation::error_t einsum_ir::py::TensorOperation::optimize
   
   return error_t::success;
 }
+
+#ifdef ETOPS_USE_PAPI
+einsum_ir::py::TensorOperation::error_t einsum_ir::py::TensorOperation::papi_setup(){
+  if( !m_papi_enabled ) {
+    return error_t::success;
+  }
+
+  // Initialize PAPI library
+  int papi_error = PAPI_library_init(PAPI_VER_CURRENT);
+  if (papi_error != PAPI_VER_CURRENT) {
+    std::cerr << "Failed to initialize PAPI: " << PAPI_strerror(papi_error) << std::endl;
+    return error_t::compilation_failed;
+  }
+
+  if( m_papi_event_names.size() == 0 ) {
+    m_papi_event_names = { "PAPI_TOT_INS", "PAPI_TOT_CYC" };
+  }
+
+  // Re-initialize eventset if setup is called more than once.
+  if( papi_event_set != PAPI_NULL ) {
+    PAPI_cleanup_eventset( papi_event_set );
+    PAPI_destroy_eventset( &papi_event_set );
+    papi_event_set = PAPI_NULL;
+  }
+
+  // Create an event set
+  papi_error = PAPI_create_eventset(&papi_event_set);
+  if (papi_error != PAPI_OK) {
+    std::cerr << "Failed to create PAPI event set: " << PAPI_strerror(papi_error) << std::endl;
+    return error_t::compilation_failed;
+  }
+
+  m_papi_event_values.assign( m_papi_event_names.size(), 0 );
+
+  for( std::size_t l_event_id = 0; l_event_id < m_papi_event_names.size(); ++l_event_id ) {
+    int l_event_code = 0;
+    papi_error = PAPI_event_name_to_code( const_cast<char *>(m_papi_event_names[l_event_id].c_str()),
+                                          &l_event_code );
+    if( papi_error != PAPI_OK ) {
+      std::cerr << "Failed to resolve PAPI event '" << m_papi_event_names[l_event_id]
+                << "': " << PAPI_strerror(papi_error) << std::endl;
+      return error_t::invalid_papi_config;
+    }
+
+    papi_error = PAPI_add_event( papi_event_set, l_event_code );
+    if( papi_error != PAPI_OK ) {
+      std::cerr << "Failed to add PAPI event '" << m_papi_event_names[l_event_id]
+                << "': " << PAPI_strerror(papi_error) << std::endl;
+      return error_t::invalid_papi_config;
+    }
+  }
+
+  return error_t::success;
+}
+
+void einsum_ir::py::TensorOperation::papi_start() {
+  int papi_error = PAPI_start(papi_event_set);
+  if (papi_error != PAPI_OK) {
+    std::cerr << "Failed to start PAPI: " << PAPI_strerror(papi_error) << std::endl;
+  }
+}
+
+void einsum_ir::py::TensorOperation::papi_stop() {
+  int papi_error = PAPI_stop(papi_event_set, m_papi_event_values.data());
+  if (papi_error != PAPI_OK) {
+    std::cerr << "Failed to stop PAPI: " << PAPI_strerror(papi_error) << std::endl;
+  }
+}
+
+void einsum_ir::py::TensorOperation::papi_print_results() {
+  std::cout << "PAPI Event Results:" << std::endl;
+  for( std::size_t i = 0; i < m_papi_event_values.size(); ++i ) {
+    std::cout << "  " << m_papi_event_names[i] << ": " << m_papi_event_values[i] << std::endl;
+  }
+}
+#endif

--- a/python/src/TensorOperation.h
+++ b/python/src/TensorOperation.h
@@ -4,6 +4,7 @@
 #include <cstdint>
 #include <vector>
 #include <iostream>
+#include <string>
 #include <einsum_ir/basic/unary/UnaryBackendTpp.h>
 #include <einsum_ir/basic/unary/UnaryOptimizer.h>
 #include <einsum_ir/basic/binary/ContractionBackendTpp.h>
@@ -83,12 +84,35 @@ class einsum_ir::py::TensorOperation {
       success                     = 0,
       compilation_failed          = 1,
       invalid_stride_shape        = 2,
-      invalid_optimization_config = 3
+      invalid_optimization_config = 3,
+      invalid_papi_config         = 4
     };
 
     op_type_t m_op_type = op_type_t::undefined;
     einsum_ir::basic::UnaryBackendTpp m_backend_unary;
     einsum_ir::basic::ContractionBackendTpp m_backend_binary;
+
+#ifdef ETOPS_USE_PAPI
+  bool m_papi_enabled = false;
+    int papi_event_set = PAPI_NULL;
+  std::vector< long_long > m_papi_event_values;
+  std::vector< std::string > m_papi_event_names;
+#endif
+
+  /**
+   * Configures PAPI profile and optional custom events.
+   *
+   * Supported profiles:
+  *  - default: PAPI_TOT_INS, PAPI_TOT_CYC
+   *  - cache: PAPI_L1_DCM, PAPI_L2_DCM, PAPI_L3_DCM, PAPI_TLB_DM
+   *  - custom: uses i_events
+   *
+   * @param i_profile selected profile name.
+   * @param i_events  user-specified events for custom profile.
+   * @return          Appropriate error code.
+   **/
+  error_t set_papi_config( std::string const & i_profile,
+                           std::vector< std::string > const & i_events );
 
     /**
      * Setup for a binary tensor contraction or a unary tensor operation.
@@ -127,7 +151,15 @@ class einsum_ir::py::TensorOperation {
     void execute( void const * tensor_in0,
                   void const * tensor_in1,
                   void       * tensor_out );
+#ifdef ETOPS_USE_PAPI
+    error_t papi_setup();
 
+    void papi_start();
+
+    void papi_stop();
+
+    void papi_print_results();
+#endif
     /**
      * Optimizes a tensor operation configuration.
      *

--- a/python/src/TensorOperation.h
+++ b/python/src/TensorOperation.h
@@ -3,10 +3,15 @@
 
 #include <cstdint>
 #include <vector>
+#include <iostream>
 #include <einsum_ir/basic/unary/UnaryBackendTpp.h>
 #include <einsum_ir/basic/unary/UnaryOptimizer.h>
 #include <einsum_ir/basic/binary/ContractionBackendTpp.h>
 #include <einsum_ir/basic/binary/ContractionOptimizer.h>
+
+#ifdef ETOPS_USE_PAPI
+#include "papi.h"
+#endif 
 
 namespace einsum_ir {
   namespace py {

--- a/python/src/bindings.cpp
+++ b/python/src/bindings.cpp
@@ -13,6 +13,7 @@ PYBIND11_MODULE(_etops_core, m) {
     .value("compilation_failed", TensorOperation::error_t::compilation_failed)
     .value("invalid_stride_shape", TensorOperation::error_t::invalid_stride_shape)
     .value("invalid_optimization_config", TensorOperation::error_t::invalid_optimization_config)
+    .value("invalid_papi_config", TensorOperation::error_t::invalid_papi_config)
     .export_values();
 
   py::enum_<TensorOperation::dtype_t>(m, "DataType" )
@@ -114,6 +115,40 @@ PYBIND11_MODULE(_etops_core, m) {
       py::arg("exec_types"),
       py::arg("dim_sizes"),
       py::arg("strides")
+    )
+    .def(
+      "configure_papi",
+      [](
+        TensorOperation                & self,
+        std::string              const & papi_profile,
+        std::vector<std::string> const & papi_events
+      ) -> TensorOperation::error_t {
+        TensorOperation::error_t l_papi_err = self.set_papi_config( papi_profile,
+                                                                    papi_events );
+        if( l_papi_err != TensorOperation::error_t::success ) {
+          return l_papi_err;
+        }
+
+#ifdef ETOPS_USE_PAPI
+        return self.papi_setup();
+#else
+        return TensorOperation::error_t::success;
+#endif
+      },
+      R"doc(
+        Configure and initialize PAPI event collection.
+
+        Supported profiles:
+          - default: PAPI_TOT_INS, PAPI_TOT_CYC
+          - cache: PAPI_L1_DCM, PAPI_L2_DCM, PAPI_L3_DCM, PAPI_TLB_DM
+          - custom: uses the supplied papi_events
+
+        :param papi_profile: PAPI profile ('default', 'cache', or 'custom').
+        :param papi_events: PAPI event names used only when papi_profile='custom'.
+        :return: Appropriate error code.
+      )doc",
+      py::arg("papi_profile") = "default",
+      py::arg("papi_events") = std::vector<std::string>{}
     )
     .def(
       "execute",

--- a/python/src/etops/__init__.py
+++ b/python/src/etops/__init__.py
@@ -164,12 +164,29 @@ class TensorOperationConfig:
     dim_sizes:  Sequence[int]
     strides:    Sequence[Sequence[Sequence[int]]]  # [LEVEL][TENSOR][DIMENSION]
     backend:    Optional[str] = None
+    papi_profile: Optional[str] = None
+    papi_events: Sequence[str] = ()
 
     def __post_init__(self):
         """Validate configuration at creation time."""
         # Validate backend
         if self.backend is not None and self.backend != "tpp":
             raise ValueError(f"Unsupported backend: '{self.backend}'. Currently only 'tpp' is supported.")
+
+        if self.papi_profile is not None:
+            allowed_profiles = {"default", "cache", "custom"}
+            if self.papi_profile not in allowed_profiles:
+                raise ValueError(
+                    f"Unsupported papi_profile: '{self.papi_profile}'. "
+                    "Supported values are 'default', 'cache', 'custom'."
+                )
+
+            if self.papi_profile == "custom":
+                if len(self.papi_events) == 0:
+                    raise ValueError("papi_events must not be empty when papi_profile='custom'.")
+                for i, event_name in enumerate(self.papi_events):
+                    if not isinstance(event_name, str) or len(event_name.strip()) == 0:
+                        raise ValueError(f"papi_events[{i}] must be a non-empty string.")
 
         # Determine operation type from prim_main
         is_binary = self.prim_main in [PrimType.gemm, PrimType.brgemm]
@@ -281,6 +298,11 @@ class TensorOperationConfig:
         if err != ErrorType.success:
             raise RuntimeError(f"einsum_ir TensorOperation setup failed: {err}")
 
+        if self.papi_profile is not None:
+            err = op.configure_papi(self.papi_profile, tuple(self.papi_events))
+            if err != ErrorType.success:
+                raise RuntimeError(f"einsum_ir PAPI setup failed: {err}")
+
     def to_json(self, indent: Optional[int] = None) -> str:
         """
         Serialize this configuration to a JSON string.
@@ -317,6 +339,9 @@ class TensorOperationConfig:
         # Only include backend if it's not None
         if self.backend is not None:
             data["backend"] = self.backend
+        if self.papi_profile is not None:
+            data["papi_profile"] = self.papi_profile
+            data["papi_events"] = list(self.papi_events)
         return json.dumps(data, indent=indent)
 
     @classmethod
@@ -365,7 +390,9 @@ class TensorOperationConfig:
                 tuple(tuple(tensor) for tensor in level)
                 for level in data["strides"]
             ),
-            backend=data.get("backend")
+            backend=data.get("backend"),
+            papi_profile=data.get("papi_profile"),
+            papi_events=tuple(data.get("papi_events", []))
         )
 
     def save(self, path: str, indent: Optional[int] = 2) -> None:
@@ -509,7 +536,9 @@ def optimize(
         dim_types=opt_dim_types,
         exec_types=opt_exec_types,
         dim_sizes=opt_dim_sizes,
-        strides=opt_strides
+        strides=opt_strides,
+        papi_profile=config.papi_profile,
+        papi_events=config.papi_events
     )
 
 __all__ = [

--- a/samples/profile/profile_matmul.py
+++ b/samples/profile/profile_matmul.py
@@ -1,0 +1,38 @@
+import etops
+
+top_config = etops.TensorOperationConfig(
+    backend    =   "tpp",
+    data_type  =   etops.float32,
+    prim_first =   etops.prim.zero,
+    prim_main  =   etops.prim.gemm,
+    prim_last  =   etops.prim.none,
+    dim_types  =   (etops.dim.m,     etops.dim.n,     etops.dim.k    ),
+    exec_types =   (etops.exec.prim, etops.exec.prim, etops.exec.prim),
+    dim_sizes  =   (1024,            1024,            1024           ),
+    strides    = (((1,               0,               1024           ),   # in0
+                   (0,               1024,            1              ),   # in1
+                   (1,               1024,            0              )),) # out
+)
+
+# Create the TensorOperation instance
+top = etops.TensorOperation(top_config)
+
+top.configure_papi("default")
+
+# Create input and output arrays
+import numpy as np
+A = np.random.randn(1024,1024).astype(np.float32)
+B = np.random.randn(1024,1024).astype(np.float32)
+C = np.random.randn(1024, 1024).astype(np.float32)
+
+# Execute the operation
+top.execute(A, B, C)
+
+C_np = np.einsum("km,nk->nm", A, B)
+
+# Compute absolute and relative errors
+error_abs = np.max( np.abs(C - C_np) )
+error_rel = np.max( np.abs(C - C_np) / (np.abs(C_np) + 1e-8) )
+print("Column-major GEMM operation:")
+print(f"  Max absolute error: {error_abs:.6e}")
+print(f"  Max relative error: {error_rel:.6e}")


### PR DESCRIPTION
This PR introduces optional support for the PAPI in etops.

PAPI support is disabled by default. To enable it, build ETOPs with:
`pip install -ve . -Ccmake.define.ETOPS_USE_PAPI=ON`

Usage:
```
top = etops.TensorOperation(top_config)
# Enable PAPI profiling
top.configure_papi("default")
```

Configuration options:
- default: PAPI_TOT_INS, PAPI_TOT_CYC
- cache: PAPI_L1_DCM, PAPI_L2_DCM, PAPI_L3_DCM, PAPI_TLB_DM
- custom: use other PAPI events as a list of strings

Limitations:
- PAPI support requires a system with compatible hardware performance counters.
- The number and type of available events depend on the underlying CPU.
